### PR TITLE
Add code to update sys.path when PYTHONPATH changes

### DIFF
--- a/envmodules.py
+++ b/envmodules.py
@@ -6,7 +6,7 @@ from subprocess import run, PIPE
 
 __version__ = '0.1'
 
-_cached_pythonpath = os.environ['PYTHONPATH']
+_cached_pythonpath = os.getenv('PYTHONPATH', '')
 _auto_fix_sys_path = 0
 
 def _modulecmd(*args):
@@ -40,7 +40,7 @@ def get_auto_fix_sys_path():
 
 def fix_sys_path():
     global _cached_pythonpath
-    pypath = os.environ['PYTHONPATH']
+    pypath = os.getenv('PYTHONPATH', '')
     if pypath == _cached_pythonpath:
         # Nothing to do if PYTHONPATH has not changed
         return

--- a/envmodules.py
+++ b/envmodules.py
@@ -1,9 +1,13 @@
 """Python wrapper around environment modules ("module load")
 """
 import os
+import sys
 from subprocess import run, PIPE
 
 __version__ = '0.1'
+
+_cached_pythonpath = os.environ['PYTHONPATH']
+_auto_fix_sys_path = 0
 
 def _modulecmd(*args):
     cmd = ['modulecmd', 'python'] + list(args)
@@ -18,8 +22,60 @@ def _modulecmd(*args):
     if code:
         exec(code, {'os': os})
 
+    if _auto_fix_sys_path:
+        fix_sys_path()
+
 def load(*args):
     _modulecmd('load', *args)
 
 def unload(*args):
     _modulecmd('unload', *args)
+
+def set_auto_fix_sys_path(new):
+    global _auto_fix_sys_path
+    _auto_fix_sys_path = bool(new)
+
+def get_auto_fix_sys_path():
+    return _auto_fix_sys_path
+
+def fix_sys_path():
+    global _cached_pythonpath
+    pypath = os.environ['PYTHONPATH']
+    if pypath == _cached_pythonpath:
+        # Nothing to do if PYTHONPATH has not changed
+        return
+
+    # PYTHONPATH has changed, see what changed
+    oldpypaths = _cached_pythonpath.split(':')
+    newpypaths = pypath.split(':')
+
+    oldpyset = set(oldpypaths)
+    newpyset = set(newpypaths)
+
+    oldpyonly = []
+    newpyonly = []
+
+    # Find elements only in oldpypaths
+    for path in oldpypaths:
+        if path not in newpyset:
+            oldpyonly.append(path)
+
+    # Find elements only in newpypaths
+    # We reverse the order for this list (prepend instead of append)
+    for path in newpypaths:
+        if path not in oldpyset:
+            newpyonly.insert(0, path)
+
+    # Modify sys.path
+    # Remove from sys.path paths in oldpypaths only
+    for path in oldpyonly:
+        sys.path.remove(path)
+
+    # Prepend to sys.path paths in newpypaths only
+    for path in newpyonly:
+        sys.path.insert(0, path)
+
+    # Cache the new PYTHONPATH
+    _cached_pythonpath = pypath
+
+


### PR DESCRIPTION
See #1 

This patch attempts to cause updates to PYTHONPATH when modules loaded/unloaded via
envmodules to cause corresponding updates to sys.path, so that one can in theory use envmodules to load a modulefile for a python module and then import the python module in the same python session.

It adds a routine
fix_sys_path() which compares PYTHONPATH before and after calls to modulecmd, and if they
differ see what paths were added/removed, and add/remove them from sys.path.  It is a bit crude in that it currently only checks for presence/absence of a path in PYTHONPATH; a more proper approach should detect changes in ordering of paths, and do more to preserve the correct order.

The _modulecmd() method was modified to optionally invoke fix_sys_path() after each call depending on the value of a private boolean data member _auto_fix_sys_path.  An accessor and mutator (get_auto_fix_sys_path() and set_auto_fix_sys_path()) for this data member also provided.